### PR TITLE
Fix Laravel 12 compatibility and IBAN validation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG.md
 
+## v2.0.0 (2025-02-07)
+- Added support for PHP 8.2+ and Laravel 12
+- Added MOD-97 checksum validation (ISO 7064)
+- Added case-insensitive IBAN input (lowercase is now accepted)
+- Replaced special character blocklist regex with allowlist
+- Fixed Lang facade error handling outside Laravel context
+- Upgraded to PHPUnit 10/11
+- Removed `setValidator()` method (was dead code)
+
 ## v1.0.2 (2023-12-31)
 - Fix on validator  🚑  [[Commit: c4033d4]](https://github.com/Nembie/iban-rule/commit/c4033d49aa4a312b3087e7d9aaaf5d6f27623243)
 - Added custom error message 👽 [[Commit: a78c58f]](https://github.com/Nembie/iban-rule/commit/a78c58fb31d603c18e447e9dd828fc15cd5b5a05)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This package provides a custom validation rule for Laravel to validate International Bank Account Numbers (IBANs). It uses the validation rules defined by the Single Euro Payments Area (SEPA) and other non-SEPA countries to ensure that the given IBAN is valid.
 
 ### 🧰 Requirements
-- ```PHP >= 8.1```
+- ```PHP >= 8.2```
 - ```Laravel >= 10```
 
 ### ⚙️ Installation

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nembie/iban-rule",
     "description": "A Laravel validation rule to validate IBAN numbers",
-    "version": "1.0.3",
+    "version": "2.0.0",
     "keywords": [
         "laravel",
         "validation",
@@ -15,7 +15,6 @@
         {
             "name": "Luca P",
             "email": "lucapacitto.dev@gmail.com",
-            "homepage": "https://nembie.it",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/validation": ">=10.0 || ^11.0"
+        "php": "^8.2",
+        "illuminate/validation": "^10.0 || ^11.0 || ^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "scripts": {
         "test": "phpunit tests"

--- a/src/ValidIban.php
+++ b/src/ValidIban.php
@@ -4,9 +4,7 @@ namespace Nembie\IbanRule;
 
 use Closure;
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Translation\PotentiallyTranslatedString;
 
 class ValidIban implements ValidationRule
 {
@@ -18,19 +16,7 @@ class ValidIban implements ValidationRule
     protected static $countryRules;
 
     /**
-     * The validator instance.
-     *
-     * @var Validator
-     */
-    protected $validator;
-
-    /**
      * Run the validation rule.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  \Closure(string): PotentiallyTranslatedString  $fail
-     * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -39,26 +25,12 @@ class ValidIban implements ValidationRule
     }
 
     /**
-     * Set the validator instance.
-     *
-     * @param  Validator  $validator
-     * @return void
-     */
-    public function setValidator($validator): void
-    {
-        $this->validator = $validator;
-    }
-
-    /**
      * Validate IBAN.
-     *
-     * @param  string  $iban
-     * @return bool
      */
-    protected function checkIBAN($iban): bool
+    protected function checkIBAN(string $iban): bool
     {
-        // Check if IBAN contains white space or special characters
-        if (preg_match('/\s|[\'^£$%&*()}{@#~?<>,|=_+¬-]/', $iban))
+        // IBAN must contain only uppercase letters and digits
+        if (!preg_match('/^[A-Z0-9]+$/', $iban))
             return false;
 
         $countryRules = $this->getCountryRules();
@@ -72,7 +44,7 @@ class ValidIban implements ValidationRule
         // Get validation rules
         $rules = array_map(fn($attr) => $attr[1], $countryObj);
 
-        // Validate IBAN against rules
+        // Validate IBAN structure against country rules
         $tempIban = $iban;
         $ibanLength = 0;
 
@@ -82,14 +54,43 @@ class ValidIban implements ValidationRule
             $checkString = substr($tempIban, 0, $numbers);
             $ibanLength += $numbers;
 
-            // Check if the string part is of the correct type
             if (($letter === 'a' && !ctype_alpha($checkString)) || ($letter === 'n' && !ctype_digit($checkString)))
                 return false;
 
             $tempIban = substr($tempIban, $numbers);
         }
 
-        return $ibanLength == strlen($iban);
+        if ($ibanLength !== strlen($iban))
+            return false;
+
+        // Validate MOD-97 checksum (ISO 7064)
+        return $this->validateMod97($iban);
+    }
+
+    /**
+     * Validate IBAN checksum using MOD-97 algorithm (ISO 7064).
+     */
+    protected function validateMod97(string $iban): bool
+    {
+        // Move the first 4 characters to the end
+        $rearranged = substr($iban, 4) . substr($iban, 0, 4);
+
+        // Replace each letter with two digits (A=10, B=11, ..., Z=35)
+        $numericString = '';
+        for ($i = 0, $len = strlen($rearranged); $i < $len; $i++) {
+            $char = $rearranged[$i];
+            $numericString .= ctype_alpha($char)
+                ? (ord($char) - ord('A') + 10)
+                : $char;
+        }
+
+        // Compute remainder digit by digit to avoid big integer overflow
+        $remainder = 0;
+        for ($i = 0, $len = strlen($numericString); $i < $len; $i++) {
+            $remainder = ($remainder * 10 + (int) $numericString[$i]) % 97;
+        }
+
+        return $remainder === 1;
     }
 
     /**
@@ -113,17 +114,19 @@ class ValidIban implements ValidationRule
 
     /**
      * Get the validation error message.
-     *
-     * @param  Closure  $fail
      */
     protected function error(Closure $fail)
     {
-        $this->validator && $this->validator->errors();
+        $message = 'The :attribute is not a valid IBAN.';
 
-        return $fail(
-            (!class_exists('Lang') || !Lang::has('validation.iban')) ?
-                'The :attribute is not a valid IBAN.'
-                : Lang::get('validation.iban')
-        );
+        try {
+            if (Lang::has('validation.iban')) {
+                $message = Lang::get('validation.iban');
+            }
+        } catch (\RuntimeException) {
+            // Lang facade not available outside Laravel
+        }
+
+        return $fail($message);
     }
 }

--- a/src/ValidIban.php
+++ b/src/ValidIban.php
@@ -29,7 +29,9 @@ class ValidIban implements ValidationRule
      */
     protected function checkIBAN(string $iban): bool
     {
-        // IBAN must contain only uppercase letters and digits
+        $iban = strtoupper($iban);
+
+        // IBAN must contain only letters and digits
         if (!preg_match('/^[A-Z0-9]+$/', $iban))
             return false;
 

--- a/tests/ValidIbanTest.php
+++ b/tests/ValidIbanTest.php
@@ -76,6 +76,6 @@ class ValidIbanTest extends TestCase
             $failed = true;
         });
 
-        $this->assertTrue($failed, 'Validation should have failed for lowercase IBAN.');
+        $this->assertFalse($failed, 'Lowercase IBAN should be accepted after normalization.');
     }
 }

--- a/tests/ValidIbanTest.php
+++ b/tests/ValidIbanTest.php
@@ -5,112 +5,77 @@ use PHPUnit\Framework\TestCase;
 
 class ValidIbanTest extends TestCase
 {
-    /**
-     * Test a valid IBAN.
-     * 
-     * @return void
-     */
     public function testValidIban(): void
     {
         $ibanValidator = new ValidIban();
-    
-        $validIban = 'DE02100500000024290661';
-    
-        $validatorMock = $this->getMockBuilder('Illuminate\Validation\Validator')
-            ->disableOriginalConstructor()
-            ->getMock();
-    
-        $validatorMock->expects($this->never())
-            ->method('errors');
-    
-        // Pass a Closure as the third argument to the validate method
-        $ibanValidator->validate('iban', $validIban, function () {
-            // The validation should not fail, so this function should not be called.
-            $this->fail('Validation failed for a valid IBAN.');
+        $failed = false;
+
+        $ibanValidator->validate('iban', 'DE02100500000024290661', function () use (&$failed) {
+            $failed = true;
         });
+
+        $this->assertFalse($failed, 'Validation should not have failed for a valid IBAN.');
     }
 
-    /**
-     * Test an invalid IBAN.
-     * 
-     * @return void
-     */
     public function testInvalidIban(): void
     {
         $ibanValidator = new ValidIban();
-        
-        $invalidIban = 'ABCD12345667';
-    
-        $validatorMock = $this->getMockBuilder('Illuminate\Validation\Validator')
-            ->disableOriginalConstructor()
-            ->getMock();
-    
-        $validatorMock->expects($this->once())
-            ->method('errors')
-            ->willReturn('The :attribute is not a valid IBAN.');
-    
-        $ibanValidator->setValidator($validatorMock);
-        
-        // Pass a Closure as the third argument to the validate method
-        $ibanValidator->validate('iban', $invalidIban, function ($message) {
-            // The validation should fail, so this function should be called.
+        $failed = false;
+
+        $ibanValidator->validate('iban', 'ABCD12345667', function ($message) use (&$failed) {
+            $failed = true;
             $this->assertEquals('The :attribute is not a valid IBAN.', $message);
         });
+
+        $this->assertTrue($failed, 'Validation should have failed for an invalid IBAN.');
     }
 
-    /**
-     * Test an IBAN with white space.
-     * 
-     * @return void
-     */
     public function testIbanWithWhiteSpace(): void
     {
         $ibanValidator = new ValidIban();
-        
-        $ibanWithWhiteSpace = 'DE02 1005 0000 0024 2906 61';
-    
-        $validatorMock = $this->getMockBuilder('Illuminate\Validation\Validator')
-            ->disableOriginalConstructor()
-            ->getMock();
-    
-        $validatorMock->expects($this->once())
-            ->method('errors')
-            ->willReturn('The :attribute is not a valid IBAN.');
-    
-        $ibanValidator->setValidator($validatorMock);
-        
-        // Pass a Closure as the third argument to the validate method
-        $ibanValidator->validate('iban', $ibanWithWhiteSpace, function ($message) {
-            // The validation should fail, so this function should be called.
-            $this->assertEquals('The :attribute is not a valid IBAN.', $message);
+        $failed = false;
+
+        $ibanValidator->validate('iban', 'DE02 1005 0000 0024 2906 61', function () use (&$failed) {
+            $failed = true;
         });
+
+        $this->assertTrue($failed, 'Validation should have failed for IBAN with whitespace.');
     }
 
-    /**
-     * Test an IBAN with special characters.
-     * 
-     * @return void
-     */
     public function testIbanWithSpecialCharacters(): void
     {
         $ibanValidator = new ValidIban();
-        
-        $ibanWithSpecialCharacters = 'DE02!1005 0000 0024 2906 61';
-    
-        $validatorMock = $this->getMockBuilder('Illuminate\Validation\Validator')
-            ->disableOriginalConstructor()
-            ->getMock();
-    
-        $validatorMock->expects($this->once())
-            ->method('errors')
-            ->willReturn('The :attribute is not a valid IBAN.');
-    
-        $ibanValidator->setValidator($validatorMock);
-        
-        // Pass a Closure as the third argument to the validate method
-        $ibanValidator->validate('iban', $ibanWithSpecialCharacters, function ($message) {
-            // The validation should fail, so this function should be called.
-            $this->assertEquals('The :attribute is not a valid IBAN.', $message);
+        $failed = false;
+
+        $ibanValidator->validate('iban', 'DE02!100500000024290661', function () use (&$failed) {
+            $failed = true;
         });
+
+        $this->assertTrue($failed, 'Validation should have failed for IBAN with special characters.');
+    }
+
+    public function testIbanWithInvalidChecksum(): void
+    {
+        $ibanValidator = new ValidIban();
+        $failed = false;
+
+        // Structurally valid German IBAN but with wrong checksum (00 instead of 02)
+        $ibanValidator->validate('iban', 'DE00100500000024290661', function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertTrue($failed, 'Validation should have failed for IBAN with invalid MOD-97 checksum.');
+    }
+
+    public function testIbanWithLowercaseCharacters(): void
+    {
+        $ibanValidator = new ValidIban();
+        $failed = false;
+
+        $ibanValidator->validate('iban', 'de02100500000024290661', function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertTrue($failed, 'Validation should have failed for lowercase IBAN.');
     }
 }


### PR DESCRIPTION
 ## Description                                                                                                                     
  - Add Laravel 12 and PHPUnit 10/11 support, bump minimum PHP to 8.2
  - Add MOD-97 checksum validation (ISO 7064) — previously only structure was checked
  - Replace special character blocklist regex with `[A-Z0-9]` allowlist
  - Fix `error()` method: remove dead `$this->validator->errors()` call, replace fragile `class_exists('Lang')` with try/catch
  - Rewrite tests for PHPUnit 11 compatibility (remove deprecated `getMockBuilder`)